### PR TITLE
Add FastAPI base with order module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Crioya Sales App
+
+Aplicaci\u00f3n b\u00e1sica de gesti\u00f3n de ventas para una empresa de papas criollas.
+
+## Requisitos
+
+- Python 3.8+
+- Dependencias del archivo `requirements.txt`
+
+## Uso
+
+Instalar dependencias:
+
+```bash
+pip install -r requirements.txt
+```
+
+Ejecutar la aplicaci\u00f3n:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Abrir en el navegador `http://localhost:8000`.
+
+La aplicación cuenta con un formulario para registrar pedidos que también se
+utiliza en el módulo de atención al cliente.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,104 @@
+from fastapi import FastAPI, Request, Form
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from fastapi.staticfiles import StaticFiles
+from typing import List
+
+app = FastAPI()
+
+templates = Jinja2Templates(directory="templates")
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+# Dummy product data
+PRODUCTS = {
+    "papa_criolla": {
+        "sizes": ["pequeña", "mediana", "grande"],
+        "label": "Papa Criolla"
+    },
+    "papa_sabanera": {
+        "sizes": ["1kg", "2kg", "5kg"],
+        "label": "Papa Sabanera"
+    },
+}
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+@app.get("/main", response_class=HTMLResponse)
+async def main_page(request: Request):
+    return templates.TemplateResponse("main.html", {"request": request})
+
+@app.get("/pedidos", response_class=HTMLResponse)
+async def pedidos_form(request: Request):
+    return templates.TemplateResponse(
+        "pedidos.html",
+        {
+            "request": request,
+            "products": PRODUCTS,
+            "titulo": "Registro de Pedido",
+        },
+    )
+
+async def _procesar_pedido(
+    request: Request,
+    productos: List[str],
+    cantidades: List[int],
+    tamanos: List[str],
+):
+    """Genera la respuesta con el resumen del pedido."""
+    pedido = []
+    for producto, cantidad, tamano in zip(productos, cantidades, tamanos):
+        pedido.append({
+            "producto": producto,
+            "cantidad": cantidad,
+            "tamano": tamano,
+        })
+    return templates.TemplateResponse(
+        "pedido_resumen.html", {"request": request, "pedido": pedido}
+    )
+
+
+@app.post("/pedidos", response_class=HTMLResponse)
+async def submit_pedido(
+    request: Request,
+    productos: List[str] = Form(...),
+    cantidades: List[int] = Form(...),
+    tamanos: List[str] = Form(...),
+):
+    return await _procesar_pedido(request, productos, cantidades, tamanos)
+
+@app.get("/atencion", response_class=HTMLResponse)
+async def atencion(request: Request):
+    return templates.TemplateResponse(
+        "pedidos.html",
+        {
+            "request": request,
+            "products": PRODUCTS,
+            "titulo": "Atenci\u00f3n al Cliente",
+        },
+    )
+
+
+@app.post("/atencion", response_class=HTMLResponse)
+async def submit_atencion(
+    request: Request,
+    productos: List[str] = Form(...),
+    cantidades: List[int] = Form(...),
+    tamanos: List[str] = Form(...),
+):
+    return await _procesar_pedido(request, productos, cantidades, tamanos)
+
+@app.get("/facturas", response_class=HTMLResponse)
+async def facturas(request: Request):
+    return templates.TemplateResponse(
+        "placeholder.html",
+        {"request": request, "titulo": "Revisar Facturas"},
+    )
+
+@app.get("/informe", response_class=HTMLResponse)
+async def informe(request: Request):
+    return templates.TemplateResponse(
+        "placeholder.html",
+        {"request": request, "titulo": "Informe Financiero"},
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+jinja2
+pydantic

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Crioya App{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/main">Crioya</a>
+    </div>
+</nav>
+<div class="container">
+    {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block title %}Inicio{% endblock %}
+{% block content %}
+<div class="text-center mt-5">
+    <h1>Bienvenido a Crioya</h1>
+    <a href="/main" class="btn btn-primary mt-3">Ingresar</a>
+</div>
+{% endblock %}

--- a/templates/main.html
+++ b/templates/main.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block title %}Menu Principal{% endblock %}
+{% block content %}
+<h2 class="mb-4">Menu Principal</h2>
+<div class="d-grid gap-2 col-6 mx-auto">
+    <a href="/pedidos" class="btn btn-success">Modulo de Pedidos</a>
+    <a href="/atencion" class="btn btn-secondary">Atención al Cliente</a>
+    <a href="/facturas" class="btn btn-secondary">Revisar Facturas</a>
+    <a href="/informe" class="btn btn-secondary">Informe Financiero</a>
+</div>
+{% endblock %}

--- a/templates/pedido_resumen.html
+++ b/templates/pedido_resumen.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block title %}Resumen de Pedido{% endblock %}
+{% block content %}
+<h2>Resumen de Pedido</h2>
+<ul class="list-group">
+    {% for item in pedido %}
+    <li class="list-group-item">
+        {{ item.producto }} - {{ item.tamano }} - Cantidad: {{ item.cantidad }}
+    </li>
+    {% endfor %}
+</ul>
+<a href="/pedidos" class="btn btn-link mt-3">Crear nuevo pedido</a>
+{% endblock %}

--- a/templates/pedidos.html
+++ b/templates/pedidos.html
@@ -1,0 +1,84 @@
+{% extends "base.html" %}
+{% block title %}{{ titulo | default('Registro de Pedido') }}{% endblock %}
+{% block content %}
+<h2 class="mb-4">{{ titulo | default('Registro de Pedido') }}</h2>
+<form method="post" id="pedido-form">
+    <div id="productos-container"></div>
+    <button type="button" class="btn btn-secondary mt-2" onclick="agregarProducto()">Agregar Producto</button>
+    <button type="submit" class="btn btn-primary mt-2">Enviar Pedido</button>
+</form>
+
+<script>
+const PRODUCTS = {{ products | tojson }};
+
+function crearSelectProducto(index) {
+    const select = document.createElement('select');
+    select.name = 'productos';
+    select.className = 'form-select mb-2';
+    select.onchange = (e) => actualizarTamanos(e.target, index);
+
+    const defaultOption = document.createElement('option');
+    defaultOption.value = '';
+    defaultOption.textContent = 'Seleccione producto';
+    select.appendChild(defaultOption);
+
+    Object.keys(PRODUCTS).forEach(key => {
+        const opt = document.createElement('option');
+        opt.value = key;
+        opt.textContent = PRODUCTS[key].label;
+        select.appendChild(opt);
+    });
+    return select;
+}
+
+function crearCantidadInput() {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.name = 'cantidades';
+    input.className = 'form-control mb-2';
+    input.placeholder = 'Cantidad';
+    return input;
+}
+
+function crearSelectTamano() {
+    const select = document.createElement('select');
+    select.name = 'tamanos';
+    select.className = 'form-select mb-2';
+    return select;
+}
+
+function actualizarTamanos(selectProducto, index) {
+    const value = selectProducto.value;
+    const selectTamano = document.getElementById('tamano-' + index);
+    selectTamano.innerHTML = '';
+    if (PRODUCTS[value]) {
+        PRODUCTS[value].sizes.forEach(size => {
+            const opt = document.createElement('option');
+            opt.value = size;
+            opt.textContent = size;
+            selectTamano.appendChild(opt);
+        });
+    }
+}
+
+let productoIndex = 0;
+function agregarProducto() {
+    const container = document.getElementById('productos-container');
+    const row = document.createElement('div');
+    row.className = 'mb-3';
+
+    const selectProducto = crearSelectProducto(productoIndex);
+    const cantidadInput = crearCantidadInput();
+    const selectTamano = crearSelectTamano();
+    selectTamano.id = 'tamano-' + productoIndex;
+
+    row.appendChild(selectProducto);
+    row.appendChild(cantidadInput);
+    row.appendChild(selectTamano);
+    container.appendChild(row);
+    productoIndex += 1;
+}
+
+document.addEventListener('DOMContentLoaded', agregarProducto);
+</script>
+{% endblock %}

--- a/templates/placeholder.html
+++ b/templates/placeholder.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}{{ titulo }}{% endblock %}
+{% block content %}
+<h2>{{ titulo }}</h2>
+<p>En construcción...</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- scaffold FastAPI project using Jinja templates
- create home page and main menu with module buttons
- implement orders form with dynamic product selection
- integrate attention to customer logic using the same form
- add placeholder pages for other modules

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_684a41e307a883328311bb8e3b072554