### PR TITLE
Implement address validation in order form

### DIFF
--- a/templates/pedidos.html
+++ b/templates/pedidos.html
@@ -98,37 +98,61 @@ function agregarProducto() {
     productoIndex += 1;
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-    agregarProducto();
-    const domicilioCheck = document.getElementById('domicilio-check');
-    const direccionInput = document.getElementById('direccion');
-    const productosContainer = document.getElementById('productos-container');
-    domicilioCheck.addEventListener('change', () => {
-        if (domicilioCheck.checked) {
-            direccionInput.disabled = false;
-            direccionInput.required = true;
-        } else {
-            direccionInput.disabled = true;
-            direccionInput.required = false;
-            direccionInput.value = '';
-        }
-    });
+    document.addEventListener('DOMContentLoaded', () => {
+        agregarProducto();
 
-    document.getElementById('pedido-form').addEventListener('submit', (e) => {
-        const cantidades = document.querySelectorAll('input[name="cantidades"]');
-        for (const input of cantidades) {
-            if (parseInt(input.value) <= 0 || isNaN(parseInt(input.value))) {
-                alert('Las cantidades deben ser mayores que cero');
+        const domicilioCheck = document.getElementById('domicilio-check');
+        const direccionInput = document.getElementById('direccion');
+        const form = document.getElementById('pedido-form');
+
+        function toggleForm(disabled) {
+            form.querySelectorAll('input, select, button').forEach(el => {
+                if (el !== direccionInput && el !== domicilioCheck) {
+                    el.disabled = disabled;
+                }
+            });
+        }
+
+        function direccionValida() {
+            return direccionInput.value.trim().length > 5;
+        }
+
+        function validarDireccion() {
+            if (domicilioCheck.checked) {
+                toggleForm(!direccionValida());
+            }
+        }
+
+        domicilioCheck.addEventListener('change', () => {
+            if (domicilioCheck.checked) {
+                direccionInput.disabled = false;
+                direccionInput.required = true;
+                validarDireccion();
+            } else {
+                direccionInput.disabled = true;
+                direccionInput.required = false;
+                direccionInput.value = '';
+                toggleForm(false);
+            }
+        });
+
+        direccionInput.addEventListener('input', validarDireccion);
+
+        document.getElementById('pedido-form').addEventListener('submit', (e) => {
+            const cantidades = document.querySelectorAll('input[name="cantidades"]');
+            for (const input of cantidades) {
+                if (parseInt(input.value) <= 0 || isNaN(parseInt(input.value))) {
+                    alert('Las cantidades deben ser mayores que cero');
+                    e.preventDefault();
+                    return;
+                }
+            }
+            if (domicilioCheck.checked && !direccionValida()) {
+                alert('Ingrese una dirección válida');
                 e.preventDefault();
                 return;
             }
-        }
-        if (domicilioCheck.checked && direccionInput.value.trim() === '') {
-            alert('Ingrese una dirección válida');
-            e.preventDefault();
-            return;
-        }
+        });
     });
-});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enable address input only when 'Entrega a domicilio' is checked
- disable rest of the form until a valid address (min 6 chars) is entered
- keep previous quantity validation logic intact

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68509b0c2f6c8332b192691a34219b4b