### PR TITLE
Implement address validation in order form

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,17 +9,98 @@ app = FastAPI()
 templates = Jinja2Templates(directory="templates")
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
-# Dummy product data with emojis in the labels
-PRODUCTS = {
-    "papa_criolla": {
-        "sizes": ["pequeña", "mediana", "grande"],
-        "label": "🥔 Papa Criolla",
-    },
-    "papa_sabanera": {
-        "sizes": ["1kg", "2kg", "5kg"],
-        "label": "🥔 Papa Sabanera",
-    },
+# Carta completa de productos
+MENU_FORMULARIO = {
+    "Entradas": [
+        {"nombre": "Deditos de queso x5", "id": "deditos_queso", "precio": 8000},
+        {"nombre": "Croquetas de yuca", "id": "croquetas_yuca", "precio": 6000},
+        {"nombre": "Criollas crocantes", "id": "criollas_crocantes", "precio": 7000},
+    ],
+    "Papas familiares": [
+        {"nombre": "Papas a la francesa", "id": "papas_francesas", "precio": 15000},
+        {"nombre": "Papas criollas", "id": "papas_criollas", "precio": 15000},
+    ],
+    "Especial familiar": [
+        {"nombre": "Especial familiar", "id": "especial_familiar", "precio": 28000},
+    ],
+    "Mixta familiar": [
+        {"nombre": "Mixta familiar", "id": "mixta_familiar", "precio": 32000},
+    ],
+    "Crio-ya familiar": [
+        {"nombre": "Crioya familiar", "id": "crioya_familiar", "precio": 35000},
+    ],
+    "Papas personales": [
+        {"nombre": "Ranchera costeña", "id": "ranchera_costeña", "precio": 12000},
+        {"nombre": "Con Costi", "id": "con_costi", "precio": 14000},
+        {"nombre": "Crio-Ya", "id": "crioya", "precio": 15000},
+        {"nombre": "Mexicana", "id": "mexicana", "precio": 13000},
+        {"nombre": "Paisa", "id": "paisa", "precio": 14000},
+    ],
+    "Costillas personales": [
+        {"nombre": "Costillas personales", "id": "costillas_personales", "precio": 18000},
+    ],
+    "Costillas para compartir": [
+        {"nombre": "Costillas para compartir", "id": "costillas_compartir", "precio": 35000},
+    ],
+    "Hamburguesa Crioya": [
+        {"nombre": "Hamburguesa Crioya", "id": "hamburguesa_crioya", "precio": 16000},
+    ],
+    "Perro Crioya": [
+        {"nombre": "Perro Crioya", "id": "perro_crioya", "precio": 12000},
+    ],
+    "Menú infantil": [
+        {"nombre": "Menú infantil", "id": "menu_infantil", "precio": 10000},
+    ],
+    "Cono": [
+        {
+            "nombre": "Cono 2 proteínas",
+            "id": "cono_2_proteinas",
+            "precio": 8000,
+            "requiere_opciones": True,
+            "opciones": {
+                "base": ["Maíz tierno", "Madurito"],
+                "proteinas": ["Chicharrón", "Costillas BBQ", "Pollo desmechado", "Carne desmechada", "Chorizo"],
+            },
+        },
+    ],
+    "Bebidas": [
+        {"nombre": "Gaseosa personal", "id": "gaseosa_personal", "precio": 3000},
+        {"nombre": "Gaseosa litro", "id": "gaseosa_litro", "precio": 6000},
+        {"nombre": "Jugo natural en agua", "id": "jugo_agua", "precio": 4000},
+        {"nombre": "Jugo natural en leche", "id": "jugo_leche", "precio": 5000},
+        {"nombre": "Soda saborizada", "id": "soda_saborizada", "precio": 3500},
+        {"nombre": "Milo", "id": "milo", "precio": 4500},
+        {"nombre": "Aromática", "id": "aromatica", "precio": 2500},
+        {"nombre": "Tinto", "id": "tinto", "precio": 1500},
+        {"nombre": "Café con leche", "id": "cafe_leche", "precio": 3000},
+    ],
+    "Adiciones": [
+        {"nombre": "Carne desmechada BBQ", "id": "carne_desmechada_bbq", "precio": 3000},
+        {"nombre": "Carne desmechada Crioya", "id": "carne_desmechada_crioya", "precio": 3000},
+        {"nombre": "Pollo desmechado", "id": "pollo_desmechado", "precio": 2500},
+        {"nombre": "Chicharrón", "id": "chicharron", "precio": 2000},
+        {"nombre": "Costillas BBQ", "id": "costillas_bbq", "precio": 4000},
+        {"nombre": "Chorizo", "id": "chorizo", "precio": 2500},
+        {"nombre": "Salchicha ranchera", "id": "salchicha_ranchera", "precio": 2000},
+        {"nombre": "Queso mozzarella", "id": "queso_mozzarella", "precio": 1500},
+        {"nombre": "Tocineta", "id": "tocineta", "precio": 2000},
+        {"nombre": "Pico de gallo", "id": "pico_gallo", "precio": 1000},
+        {"nombre": "Madurito", "id": "madurito", "precio": 1500},
+        {"nombre": "Maíz tierno", "id": "maiz_tierno", "precio": 1500},
+    ],
 }
+
+
+def _build_products(menu: dict) -> dict:
+    """Convierte el menú en el formato utilizado por el formulario."""
+    productos = {}
+    for categoria in menu.values():
+        for item in categoria:
+            productos[item["id"]] = {"label": item["nombre"], "sizes": ["único"]}
+    return productos
+
+
+PRODUCTS = _build_products(MENU_FORMULARIO)
 
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request):

--- a/templates/pedidos.html
+++ b/templates/pedidos.html
@@ -98,37 +98,61 @@ function agregarProducto() {
     productoIndex += 1;
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-    agregarProducto();
-    const domicilioCheck = document.getElementById('domicilio-check');
-    const direccionInput = document.getElementById('direccion');
-    const productosContainer = document.getElementById('productos-container');
-    domicilioCheck.addEventListener('change', () => {
-        if (domicilioCheck.checked) {
-            direccionInput.disabled = false;
-            direccionInput.required = true;
-        } else {
-            direccionInput.disabled = true;
-            direccionInput.required = false;
-            direccionInput.value = '';
-        }
-    });
+    document.addEventListener('DOMContentLoaded', () => {
+        agregarProducto();
 
-    document.getElementById('pedido-form').addEventListener('submit', (e) => {
-        const cantidades = document.querySelectorAll('input[name="cantidades"]');
-        for (const input of cantidades) {
-            if (parseInt(input.value) <= 0 || isNaN(parseInt(input.value))) {
-                alert('Las cantidades deben ser mayores que cero');
+        const domicilioCheck = document.getElementById('domicilio-check');
+        const direccionInput = document.getElementById('direccion');
+        const form = document.getElementById('pedido-form');
+
+        function toggleForm(disabled) {
+            form.querySelectorAll('input, select, button').forEach(el => {
+                if (el !== direccionInput && el !== domicilioCheck) {
+                    el.disabled = disabled;
+                }
+            });
+        }
+
+        function direccionValida() {
+            return direccionInput.value.trim().length > 5;
+        }
+
+        function validarDireccion() {
+            if (domicilioCheck.checked) {
+                toggleForm(!direccionValida());
+            }
+        }
+
+        domicilioCheck.addEventListener('change', () => {
+            if (domicilioCheck.checked) {
+                direccionInput.disabled = false;
+                direccionInput.required = true;
+                validarDireccion();
+            } else {
+                direccionInput.disabled = true;
+                direccionInput.required = false;
+                direccionInput.value = '';
+                toggleForm(false);
+            }
+        });
+
+        direccionInput.addEventListener('input', validarDireccion);
+
+        document.getElementById('pedido-form').addEventListener('submit', (e) => {
+            const cantidades = document.querySelectorAll('input[name="cantidades"]');
+            for (const input of cantidades) {
+                if (parseInt(input.value) <= 0 || isNaN(parseInt(input.value))) {
+                    alert('Las cantidades deben ser mayores que cero');
+                    e.preventDefault();
+                    return;
+                }
+            }
+            if (domicilioCheck.checked && !direccionValida()) {
+                alert('Ingrese una dirección válida');
                 e.preventDefault();
                 return;
             }
-        }
-        if (domicilioCheck.checked && direccionInput.value.trim() === '') {
-            alert('Ingrese una dirección válida');
-            e.preventDefault();
-            return;
-        }
+        });
     });
-});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enable address input only when 'Entrega a domicilio' is checked
- disable rest of the form until a valid address (min 6 chars) is entered
- keep previous quantity validation logic intact
- include full product menu for order form

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68509b0c2f6c8332b192691a34219b4b