### PR TITLE
Add PedidoResponse schema and endpoint

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -15,3 +15,30 @@ class ClienteRegistroResponse(BaseModel):
 class ZonaResponse(BaseModel):
     response: str
     mensaje: str
+
+
+class PedidoItem(BaseModel):
+    """Información de un producto dentro de un pedido."""
+
+    producto: str
+    cantidad: int
+    tamano: str
+    adicion: str | None = None
+    detalle: str | None = None
+
+    class Config:
+        from_attributes = True
+
+
+class PedidoResponse(BaseModel):
+    """Representación completa del pedido recibido."""
+
+    nombre: str
+    telefono: str
+    direccion: str
+    domicilio: bool
+    pedido: list[PedidoItem]
+
+    class Config:
+        from_attributes = True
+


### PR DESCRIPTION
## Summary
- add `PedidoItem` and `PedidoResponse` classes in `schemas.py`
- build `PedidoResponse` in the backend using helper function
- serve order summary from the new object
- expose new `/pedido` endpoint that returns a `PedidoResponse`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68532beea3f4833296ea3b5ddd2f538e