### PR TITLE
Handle additions as list

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -143,6 +143,45 @@ async def index(request: Request):
 async def main_page(request: Request):
     return templates.TemplateResponse("main.html", {"request": request})
 
+def _crear_pedido_response(
+    productos: List[str],
+    cantidades: List[int],
+    tamanos: List[str],
+    adiciones: List[str],
+    detalles: List[str],
+    nombre_apellido: str,
+    telefono: str,
+    direccion: str,
+    domicilio: bool,
+) -> schemas.PedidoResponse:
+    """Construye un objeto de respuesta de pedido a partir de los campos del formulario."""
+    items: list[schemas.PedidoItem] = []
+    for producto, cantidad, tamano, adicion, detalle in zip(
+        productos, cantidades, tamanos, adiciones, detalles
+    ):
+        if cantidad <= 0:
+            continue
+        label = PRODUCTS.get(producto, {}).get("label", producto)
+        adiciones_list = [a.strip() for a in adicion.split(",") if a.strip()]
+        items.append(
+            schemas.PedidoItem(
+                producto=label,
+                cantidad=cantidad,
+                tamano=tamano,
+                adicion=adiciones_list or None,
+                detalle=detalle or None,
+            )
+        )
+
+    return schemas.PedidoResponse(
+        nombre=nombre_apellido,
+        telefono=telefono,
+        direccion=direccion,
+        domicilio=domicilio,
+        pedido=items,
+    )
+
+
 async def _procesar_pedido(
     request: Request,
     productos: List[str],
@@ -156,29 +195,26 @@ async def _procesar_pedido(
     domicilio: bool,
 ):
     """Genera la respuesta con el resumen del pedido."""
-    pedido = []
-    for producto, cantidad, tamano, adicion, detalle in zip(
-        productos, cantidades, tamanos, adiciones, detalles
-    ):
-        if cantidad <= 0:
-            continue
-        label = PRODUCTS.get(producto, {}).get("label", producto)
-        pedido.append({
-            "producto": label,
-            "cantidad": cantidad,
-            "tamano": tamano,
-            "adicion": adicion,
-            "detalle": detalle,
-        })
+    pedido = _crear_pedido_response(
+        productos,
+        cantidades,
+        tamanos,
+        adiciones,
+        detalles,
+        nombre_apellido,
+        telefono,
+        direccion,
+        domicilio,
+    )
     return templates.TemplateResponse(
         "pedido_resumen.html",
         {
             "request": request,
-            "pedido": pedido,
-            "nombre": nombre_apellido,
-            "telefono": telefono,
-            "direccion": direccion,
-            "domicilio": domicilio,
+            "pedido": pedido.pedido,
+            "nombre": pedido.nombre,
+            "telefono": pedido.telefono,
+            "direccion": pedido.direccion,
+            "domicilio": pedido.domicilio,
         },
     )
 
@@ -243,6 +279,32 @@ async def cocina(request: Request):
     return templates.TemplateResponse(
         "cocina.html",
         {"request": request, "titulo": "Interfaz de Cocina"},
+    )
+
+
+@app.post("/pedido", response_model=schemas.PedidoResponse)
+async def crear_pedido(
+    telefono: str = Form(...),
+    nombre_apellido: str = Form(...),
+    direccion: str = Form(""),
+    domicilio: bool = Form(False),
+    productos: List[str] = Form(...),
+    cantidades: List[int] = Form(...),
+    tamanos: List[str] = Form(...),
+    adiciones: List[str] = Form(...),
+    detalles: List[str] = Form(...),
+):
+    """Recibe los campos del formulario y devuelve un objeto de pedido."""
+    return _crear_pedido_response(
+        productos,
+        cantidades,
+        tamanos,
+        adiciones,
+        detalles,
+        nombre_apellido,
+        telefono,
+        direccion if domicilio else "",
+        domicilio,
     )
 
 @app.post('/zona', response_model=schemas.ZonaResponse)
@@ -320,3 +382,4 @@ async def obtener_cliente(telefono: str, db: Session = Depends(get_db)):
         "direccion": cliente.direccion,
         "telefono": cliente.telefono
     }
+

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -15,3 +15,25 @@ class ClienteRegistroResponse(BaseModel):
 class ZonaResponse(BaseModel):
     response: str
     mensaje: str
+
+
+class PedidoItem(BaseModel):
+    producto: str
+    cantidad: int
+    tamano: str
+    adicion: list[str] | None = None
+    detalle: str | None = None
+
+    class Config:
+        from_attributes = True
+
+
+class PedidoResponse(BaseModel):
+    nombre: str
+    telefono: str
+    direccion: str
+    domicilio: bool
+    pedido: list[PedidoItem]
+
+    class Config:
+        from_attributes = True

--- a/templates/pedido_resumen.html
+++ b/templates/pedido_resumen.html
@@ -19,7 +19,7 @@
     {% for item in pedido %}
     <li class="list-group-item">
         {{ item.producto }} - {{ item.tamano }} - Cantidad: {{ item.cantidad }}
-        {% if item.adicion %} | Adición: {{ item.adicion }}{% endif %}
+        {% if item.adicion %} | Adición: {{ item.adicion | join(", ") }}{% endif %}
         {% if item.detalle %} | Detalle: {{ item.detalle }}{% endif %}
     </li>
     {% endfor %}


### PR DESCRIPTION
## Summary
- define PedidoItem `adicion` as list of strings
- parse additions in `_crear_pedido_response`
- restore `PedidoResponse` and `/pedido` route
- show additions joined by commas in order summaries

## Testing
- `python -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68532dd01c8c833285037ab3c7bce121