### PR TITLE
Improve cookie security

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Ejecutar la aplicaci\u00f3n:
 uvicorn app.main:app --reload
 ```
 
+La aplicación utiliza cookies de sesión a través de `SessionMiddleware`. Puedes
+definir la clave de sesión estableciendo la variable de entorno
+`SESSION_SECRET`.
+
 Abrir en el navegador `http://localhost:8000`.
 
 La aplicación cuenta con un formulario para registrar pedidos que también se

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,14 @@
 from fastapi import FastAPI
+from starlette.middleware.sessions import SessionMiddleware
+import os
 
 from .routers import pages, pedido, clientes
 
 app = FastAPI()
+app.add_middleware(
+    SessionMiddleware,
+    secret_key=os.getenv("SESSION_SECRET", "change-me"),
+)
 
 app.include_router(pages.router)
 app.include_router(pedido.router)

--- a/app/routers/pedido.py
+++ b/app/routers/pedido.py
@@ -137,7 +137,14 @@ async def submit_atencion(
     msg = await nuevo_pedido(pedido)
     print(msg)
     response = RedirectResponse(url="/resumen", status_code=303)
-    response.set_cookie("ultimo_pedido", pedido.model_dump_json(), max_age=300)
+    response.set_cookie(
+        "ultimo_pedido",
+        pedido.model_dump_json(),
+        max_age=300,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+    )
     return response
 
 


### PR DESCRIPTION
## Summary
- secure `ultimo_pedido` cookie with `httponly`, `secure`, and `samesite` options
- add `SessionMiddleware` to manage cookies
- document `SESSION_SECRET` environment variable in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68586c345fbc8332849a4355515ff244