### PR TITLE
Add staff token auth for cocina WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ La aplicación cuenta con un formulario para registrar pedidos que también se
 utiliza en el módulo de atención al cliente.
 Desde la interfaz de pedidos ahora es posible agregar múltiples adiciones a un
 producto y eliminar tanto adiciones individuales como productos completos.
+## Autenticacion de cocina
+
+Para acceder al WebSocket de cocina se requiere un token. Establece la variable de entorno `STAFF_TOKEN` con un valor compartido y el navegador incluirá ese token al conectarse a `/ws/cocina`.
+

--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,7 @@ ctx = ssl.create_default_context(cafile=certifi.where())
 LOCATION_KEY = os.getenv("LOCATION_KEY")
 AZURE_KEY = os.getenv("azure_key")
 AZURE_ENDPOINT = os.getenv("azure_endpoint")
+STAFF_TOKEN = os.getenv("STAFF_TOKEN", "changeme")
 
 MENU_FORMULARIO = {
     "Entradas": [

--- a/app/routers/pedido.py
+++ b/app/routers/pedido.py
@@ -22,6 +22,7 @@ from ..config import (
     LOCAL_COORDS,
     RADIO_COBERTURA,
     cliente_azure,
+    STAFF_TOKEN,
 )
 
 router = APIRouter()
@@ -162,6 +163,10 @@ async def resumen_pedido(request: Request):
 
 @router.websocket("/ws/cocina")
 async def websocket_endpoint(websocket: WebSocket):
+    token = websocket.query_params.get("token")
+    if token != STAFF_TOKEN:
+        await websocket.close(code=1008)
+        return
     await manager.connect(websocket)
     try:
         while True:
@@ -172,7 +177,9 @@ async def websocket_endpoint(websocket: WebSocket):
 
 @router.get("/cocina", response_class=HTMLResponse)
 async def cocina(request: Request):
-    return templates.TemplateResponse("cocina.html", {"request": request})
+    return templates.TemplateResponse(
+        "cocina.html", {"request": request, "token": STAFF_TOKEN}
+    )
 
 
 @router.post("/pedido", response_model=schemas.PedidoResponse)

--- a/templates/cocina.html
+++ b/templates/cocina.html
@@ -64,7 +64,7 @@
 </style>
 
 <script>
-    const socket = new WebSocket("ws://" + window.location.host + "/ws/cocina");
+    const socket = new WebSocket("ws://" + window.location.host + "/ws/cocina?token={{ token }}");
 
     let numeroPedido = 1; // Inicializamos el contador para los números de pedidos
 


### PR DESCRIPTION
## Summary
- add `STAFF_TOKEN` env variable
- require token to connect to `/ws/cocina`
- expose token in cocina page and connect with it
- document new variable

## Testing
- `python -m py_compile $(cat /tmp/files.txt)`

------
https://chatgpt.com/codex/tasks/task_e_68586c3a4cd883328ad4cf15a73584b3