### PR TITLE
Implement custom error management

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -3,11 +3,19 @@ import ssl
 import certifi
 from dotenv import load_dotenv
 from fastapi.templating import Jinja2Templates
+from fastapi import Request
+from typing import Any
 from openai import AzureOpenAI
 
 load_dotenv()
 
 templates = Jinja2Templates(directory="templates")
+
+def render_template(request: Request, name: str, context: dict[str, Any] | None = None):
+    ctx = context or {}
+    ctx["request"] = request
+    ctx["error"] = request.session.pop("error", None)
+    return templates.TemplateResponse(name, ctx)
 ctx = ssl.create_default_context(cafile=certifi.where())
 LOCATION_KEY = os.getenv("LOCATION_KEY")
 AZURE_KEY = os.getenv("azure_key")

--- a/app/errors.py
+++ b/app/errors.py
@@ -1,0 +1,16 @@
+from fastapi import status
+
+class AppError(Exception):
+    status_code: int = status.HTTP_500_INTERNAL_SERVER_ERROR
+    message: str = "Error interno"
+
+    def __init__(self, message: str | None = None):
+        if message:
+            self.message = message
+        super().__init__(self.message)
+
+class DatabaseError(AppError):
+    status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+
+class NotFoundError(AppError):
+    status_code = status.HTTP_404_NOT_FOUND

--- a/app/main.py
+++ b/app/main.py
@@ -1,15 +1,39 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from starlette.middleware.sessions import SessionMiddleware
+from fastapi.responses import JSONResponse, RedirectResponse
+import logging
 import os
 
 from .routers import pages, pedido, clientes, facturas
 from .database import create_db_and_tables
+from .errors import AppError
 
 app = FastAPI()
 app.add_middleware(
     SessionMiddleware,
     secret_key=os.getenv("SESSION_SECRET", "change-me"),
 )
+
+logging.basicConfig(level=logging.INFO)
+
+
+@app.exception_handler(AppError)
+async def app_error_handler(request: Request, exc: AppError):
+    if request.headers.get("accept", "").startswith("text/html"):
+        request.session["error"] = exc.message
+        referer = request.headers.get("referer") or "/"
+        return RedirectResponse(referer, status_code=302)
+    return JSONResponse({"detail": exc.message}, status_code=exc.status_code)
+
+
+@app.exception_handler(Exception)
+async def generic_error_handler(request: Request, exc: Exception):
+    logging.exception("Unhandled error: %s", exc)
+    if request.headers.get("accept", "").startswith("text/html"):
+        request.session["error"] = "Ocurri\u00f3 un error inesperado"
+        referer = request.headers.get("referer") or "/"
+        return RedirectResponse(referer, status_code=302)
+    return JSONResponse({"detail": "Ocurri\u00f3 un error interno"}, status_code=500)
 
 
 app.include_router(pages.router)

--- a/app/routers/facturas.py
+++ b/app/routers/facturas.py
@@ -94,9 +94,14 @@ def generar_factura_desde_pedido(pedido: schemas.PedidoResponse, db: Session) ->
         total=total
     )
 
-    db.add(factura)
-    db.commit()
-    db.refresh(factura)
+    try:
+        db.add(factura)
+        db.commit()
+        db.refresh(factura)
+    except Exception as e:
+        db.rollback()
+        from ..errors import DatabaseError
+        raise DatabaseError("Error registrando la factura") from e
     return factura
 
 

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -1,30 +1,34 @@
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
-from ..config import templates
+from ..config import templates, render_template
 
 router = APIRouter()
 
 
 @router.get("/", response_class=HTMLResponse)
 async def index(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    return render_template(request, "index.html")
 
 
 @router.get("/main", response_class=HTMLResponse)
 async def main_page(request: Request):
-    return templates.TemplateResponse("main.html", {"request": request})
+    return render_template(request, "main.html")
 
 
 @router.get("/facturas", response_class=HTMLResponse)
 async def facturas(request: Request):
     """Vista para revisar facturas guardadas."""
-    return templates.TemplateResponse(
-        "facturas.html", {"request": request, "titulo": "Revisar Facturas"}
+    return render_template(
+        request,
+        "facturas.html",
+        {"titulo": "Revisar Facturas"},
     )
 
 
 @router.get("/informe", response_class=HTMLResponse)
 async def informe(request: Request):
-    return templates.TemplateResponse(
-        "placeholder.html", {"request": request, "titulo": "Informe Financiero"}
+    return render_template(
+        request,
+        "placeholder.html",
+        {"titulo": "Informe Financiero"},
     )

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -48,8 +48,14 @@ class ConnectionManager:
         self.active_connections.remove(websocket)
 
     async def broadcast(self, message: str):
+        dead = []
         for connection in self.active_connections:
-            await connection.send_text(message)
+            try:
+                await connection.send_text(message)
+            except Exception:
+                dead.append(connection)
+        for connection in dead:
+            self.active_connections.remove(connection)
 
 
 # 🧾 Esquema que define cómo se verá un pedido cuando se devuelva desde la base de datos

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,9 @@
     </div>
 </nav>
 <div class="container">
+    {% if error %}
+    <div class="alert alert-danger" role="alert">{{ error }}</div>
+    {% endif %}
     {% block content %}{% endblock %}
 </div>
 </body>

--- a/templates/pedidos.html
+++ b/templates/pedidos.html
@@ -36,6 +36,7 @@
 
 <script>
 const PRODUCTS = {{ products | tojson }};
+const PRELOAD = {{ pedido_data | tojson | default('null') }};
 const PRODUCT_KEYS = {};
 Object.keys(PRODUCTS).forEach(key => {
     PRODUCT_KEYS[PRODUCTS[key].label] = key;
@@ -211,6 +212,36 @@ function agregarProducto() {
 
 document.addEventListener('DOMContentLoaded', () => {
     agregarProducto();
+    if (PRELOAD) {
+        telefonoInput.value = PRELOAD.telefono || '';
+        nombreInput.value = PRELOAD.nombre || '';
+        domicilioCheck.checked = PRELOAD.domicilio;
+        if (PRELOAD.domicilio) {
+            direccionInput.disabled = false;
+            direccionInput.value = PRELOAD.direccion || '';
+        }
+        document.getElementById('productos-container').innerHTML = '';
+        productoIndex = 0;
+        (PRELOAD.pedido || []).forEach(item => {
+            agregarProducto();
+            const idx = productoIndex - 1;
+            const row = document.getElementById('productos-container').lastElementChild;
+            row.querySelector('input[list="product-list"]').value = item.producto;
+            document.getElementById('producto-key-' + idx).value = PRODUCT_KEYS[item.producto] || '';
+            actualizarTamanos(PRODUCT_KEYS[item.producto] || '', idx);
+            row.querySelector('input[name="cantidades"]').value = item.cantidad;
+            row.querySelector('select[name="tamanos"]').value = item.tamano;
+            if (item.adicion && item.adicion.length) {
+                const container = row.querySelector('.adiciones-container');
+                item.adicion.forEach(ad => {
+                    container.insertBefore(crearAdicionFila(container.updateHidden), container.lastElementChild);
+                    container.querySelectorAll('input[list="adiciones-list"]')[container.querySelectorAll('input[list="adiciones-list"]').length-1].value = ad;
+                });
+                container.updateHidden();
+            }
+            row.querySelector('textarea[name="detalles"]').value = item.detalle || '';
+        });
+    }
 
     const domicilioCheck = document.getElementById('domicilio-check');
     const direccionInput = document.getElementById('direccion');


### PR DESCRIPTION
## Summary
- create reusable `AppError` class hierarchy
- centralize error handling in `main.py`
- add helper `render_template` to inject messages
- handle DB exceptions and failed broadcasts
- preserve and reload form data when submitting orders
- display errors in base template

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685acad513f4833291f1c362a537c63f