### PR TITLE
Implement success flash messages

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -15,6 +15,7 @@ def render_template(request: Request, name: str, context: dict[str, Any] | None 
     ctx = context or {}
     ctx["request"] = request
     ctx["error"] = request.session.pop("error", None)
+    ctx["success"] = request.session.pop("success", None)
     return templates.TemplateResponse(name, ctx)
 ctx = ssl.create_default_context(cafile=certifi.where())
 LOCATION_KEY = os.getenv("LOCATION_KEY")

--- a/app/routers/pedido.py
+++ b/app/routers/pedido.py
@@ -162,6 +162,8 @@ async def submit_atencion(
         request.session["pedido_data"] = pedido.model_dump()
         raise AppError("No se pudo procesar el pedido") from e
 
+    request.session["success"] = "Pedido enviado a cocina y factura generada"
+
   
     return render_template(
         request,

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,9 @@
     {% if error %}
     <div class="alert alert-danger" role="alert">{{ error }}</div>
     {% endif %}
+    {% if success %}
+    <div class="alert alert-success" role="alert">{{ success }}</div>
+    {% endif %}
     {% block content %}{% endblock %}
 </div>
 </body>


### PR DESCRIPTION
## Summary
- allow flashing success messages via session
- show success messages in base template
- notify order completion in `submit_atencion`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_685ad00a744c8332b042a2b6cca37ff7