### PR TITLE
Add Docker deployment setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.sqlite3
+.env
+.env.*
+.git
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -54,3 +54,20 @@ STAFF_TOKEN=
 ```
 
 Puede tomar como referencia el archivo `.env.example` incluido en el repositorio.
+
+## Despliegue con Docker en Render
+
+Para generar una imagen Docker ejecuta:
+
+```bash
+docker build -t crioya-app .
+```
+
+Luego puedes probarla localmente con:
+
+```bash
+docker run --env-file .env -p 8000:8000 crioya-app
+```
+
+En Render selecciona **New Web Service**, elige el entorno *Docker* y conecta el repositorio.
+La plataforma construirá la imagen usando el `Dockerfile` y expondrá el servicio en el puerto 8000.


### PR DESCRIPTION
## Summary
- add a Dockerfile to run the FastAPI server
- ignore development files during Docker build
- document how to build and deploy on Render

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ade5cdca08332a161dc0d97f3ca39