### PR TITLE
Corrección en consulta de facturas

### DIFF
--- a/templates/cierres_historico.html
+++ b/templates/cierres_historico.html
@@ -30,7 +30,7 @@
     <tbody>
         {% for cierre in cierres %}
         <tr>
-            <td>{{ cierre.fecha.strftime("%Y-%m-%d %H:%M:%S") }}</td>
+            <td>{{ cierre.fecha_local.strftime("%Y-%m-%d %H:%M:%S") }}</td>
             <td>${{ '%.2f'|format(cierre.efectivo) }}</td>
             <td>${{ '%.2f'|format(cierre.digital) }}</td>
             <td>${{ '%.2f'|format(cierre.total_recibido) }}</td>
@@ -41,6 +41,7 @@
             <td>{{ cierre.observaciones }}</td>
         </tr>
         {% endfor %}
+
     </tbody>
 </table>
 

--- a/templates/facturas.html
+++ b/templates/facturas.html
@@ -52,7 +52,13 @@ async function cargarFacturas() {
         const tr = document.createElement('tr');
         tr.innerHTML = `
             <td>${f.numero}</td>
-            <td>${new Date(f.fecha).toLocaleString()}</td>
+            <td>${
+                new Intl.DateTimeFormat('es-CO', {
+                    dateStyle: 'short',
+                    timeStyle: 'medium',
+                    timeZone: 'America/Bogota'
+                    }).format(new Date(f.fecha))
+            }</td>
             <td>${f.cliente}</td>
             <td><pre class="td-productos">${JSON.stringify(f.productos)}</pre></td>
             <td>${f.total}</td>


### PR DESCRIPTION
En el caso del cierre, ya valida que si hayan facturas disponibles para hacer el cierre del día. Por parte de la revisión de facturas: las fechas que se muestran coinciden con la de colombia (Al usar supabase, la estaba guardando como UTC) para que los filtros queden bien. Además al descargar el excel y el pdf, las fechas coinciden con los registros