### PR TITLE
Add financial report page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from fastapi.responses import JSONResponse, RedirectResponse
 import logging
 import os
 from app.routers import pages, pedido, clientes, facturas
+from app.routers import informe
 from .database import create_db_and_tables
 from .errors import AppError
 from . import models
@@ -47,6 +48,7 @@ app.include_router(pedido.router)
 app.include_router(clientes.router)
 app.include_router(facturas.router)
 app.include_router(inventario.router)
+app.include_router(informe.router)
 
  
 

--- a/app/routers/informe.py
+++ b/app/routers/informe.py
@@ -1,0 +1,100 @@
+from fastapi import APIRouter, Request, Depends
+from fastapi.responses import HTMLResponse, StreamingResponse
+from sqlalchemy.orm import Session
+from ..dependencies import get_db
+from ..config import render_template
+from .. import models
+from datetime import datetime, timedelta
+import pandas as pd
+import json
+from fpdf import FPDF
+import io
+
+router = APIRouter()
+
+
+def _facturas_mes(db: Session, mes: str) -> pd.DataFrame:
+    """Devuelve un DataFrame con las facturas del mes YYYY-MM."""
+    inicio = datetime.strptime(mes + "-01", "%Y-%m-%d")
+    if inicio.month == 12:
+        fin = inicio.replace(year=inicio.year + 1, month=1)
+    else:
+        fin = inicio.replace(month=inicio.month + 1)
+    facturas = db.query(models.Factura).filter(models.Factura.fecha >= inicio, models.Factura.fecha < fin).all()
+    data = []
+    for f in facturas:
+        data.append({
+            "fecha": f.fecha,
+            "productos": json.loads(f.productos),
+            "total": f.total
+        })
+    df = pd.DataFrame(data)
+    return df
+
+
+def _inventario_semanal(db: Session, mes: str):
+    """Estado de inventario semana a semana."""
+    inicio = datetime.strptime(mes + "-01", "%Y-%m-%d")
+    if inicio.month == 12:
+        fin = inicio.replace(year=inicio.year + 1, month=1)
+    else:
+        fin = inicio.replace(month=inicio.month + 1)
+    semanas = []
+    actual = inicio
+    while actual < fin:
+        siguiente = actual + timedelta(days=7)
+        datos = []
+        for ins in db.query(models.Insumo).all():
+            entradas = sum(e.cantidad for e in ins.entradas if actual <= e.fecha < siguiente)
+            salidas = sum(s.cantidad for s in ins.salidas if actual <= s.fecha < siguiente)
+            datos.append({"nombre": ins.nombre, "entrada": entradas, "salida": salidas})
+        semanas.append({"inicio": actual.date(), "fin": (siguiente - timedelta(days=1)).date(), "datos": datos})
+        actual = siguiente
+    return semanas
+
+
+@router.get("/informe", response_class=HTMLResponse)
+async def informe_financiero(request: Request, mes: str = None, db: Session = Depends(get_db)):
+    mes = mes or datetime.now().strftime("%Y-%m")
+    df = _facturas_mes(db, mes)
+    total_ventas = df["total"].sum() if not df.empty else 0
+    utilidad = total_ventas * 0.3
+    ventas_por_tipo = {}
+    for _, fila in df.iterrows():
+        for p in fila["productos"]:
+            ventas_por_tipo[p["producto"]] = ventas_por_tipo.get(p["producto"], 0) + p.get("subtotal", 0)
+    inventario = _inventario_semanal(db, mes)
+    return render_template(request, "informe.html", {
+        "mes": mes,
+        "total_ventas": total_ventas,
+        "utilidad": utilidad,
+        "ventas_por_tipo": ventas_por_tipo,
+        "inventario": inventario
+    })
+
+
+@router.get("/informe/pdf")
+def informe_pdf(mes: str, db: Session = Depends(get_db)):
+    df = _facturas_mes(db, mes)
+    total_ventas = df["total"].sum() if not df.empty else 0
+    utilidad = total_ventas * 0.3
+    ventas_por_tipo = {}
+    for _, fila in df.iterrows():
+        for p in fila["productos"]:
+            ventas_por_tipo[p["producto"]] = ventas_por_tipo.get(p["producto"], 0) + p.get("subtotal", 0)
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", "B", 16)
+    pdf.cell(0, 10, f"Informe financiero {mes}", ln=True, align="C")
+    pdf.ln(5)
+    pdf.set_font("Arial", size=12)
+    pdf.cell(0, 10, f"Total ventas: ${total_ventas:,.0f}", ln=True)
+    pdf.cell(0, 10, f"Utilidad estimada: ${utilidad:,.0f}", ln=True)
+    pdf.ln(5)
+    pdf.set_font("Arial", "B", 12)
+    pdf.cell(0, 10, "Ventas por tipo de producto", ln=True)
+    pdf.set_font("Arial", size=11)
+    for k, v in ventas_por_tipo.items():
+        pdf.cell(0, 8, f"{k}: ${v:,.0f}", ln=True)
+    pdf_bytes = pdf.output(dest="S").encode("latin-1")
+    return StreamingResponse(io.BytesIO(pdf_bytes), media_type="application/pdf", headers={"Content-Disposition": f"attachment; filename=informe_{mes}.pdf"})

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -38,13 +38,7 @@ async def facturas(request: Request):
     )
 
 
-@router.get("/informe", response_class=HTMLResponse)
-async def informe(request: Request):
-    return render_template(
-        request,
-        "placeholder.html",
-        {"titulo": "Informe Financiero"},
-    )
+
 
 @router.get("/cierre", response_class=HTMLResponse)
 async def cierre_caja_form(request: Request):

--- a/templates/informe.html
+++ b/templates/informe.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block title %}Informe Financiero{% endblock %}
+{% block content %}
+<h2 class="mb-4">Informe Financiero - {{ mes }}</h2>
+<div class="mb-3">
+  <form method="get" action="/informe" class="row g-3">
+    <div class="col-auto">
+      <input type="month" name="mes" value="{{ mes }}" class="form-control">
+    </div>
+    <div class="col-auto">
+      <button type="submit" class="btn btn-primary">Generar informe financiero</button>
+    </div>
+    <div class="col-auto">
+      <a href="/informe/pdf?mes={{ mes }}" class="btn btn-secondary">Exportar informe</a>
+    </div>
+  </form>
+</div>
+<div class="mb-4">
+  <h4>Resumen de ventas</h4>
+  <p>Total ventas: ${{ '{:,.0f}'.format(total_ventas) }}</p>
+  <p>Utilidad estimada: ${{ '{:,.0f}'.format(utilidad) }}</p>
+</div>
+<div class="mb-4">
+  <h4>Ventas por tipo de producto</h4>
+  <ul>
+    {% for nombre, valor in ventas_por_tipo.items() %}
+      <li>{{ nombre }}: ${{ '{:,.0f}'.format(valor) }}</li>
+    {% endfor %}
+  </ul>
+</div>
+<div class="mb-4">
+  <h4>Estado del inventario semana a semana</h4>
+  {% for sem in inventario %}
+    <h6>Semana {{ loop.index }} ({{ sem.inicio }} - {{ sem.fin }})</h6>
+    <ul>
+      {% for item in sem.datos %}
+        <li>{{ item.nombre }}: entradas {{ item.entrada }} / salidas {{ item.salida }}</li>
+      {% endfor %}
+    </ul>
+  {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- generate monthly report and export PDF via new `informe` router
- new `/informe` UI template with buttons for generating and exporting reports
- integrate router in `app/main.py`
- remove old placeholder route

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68754910e6a08332b460c1e8fd420b7e