### PR TITLE
Add charts to PDF report

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ itsdangerous~=2.2.0
 pandas~=2.2.2
 openpyxl~=3.1.2
 fpdf~=1.7.2
+matplotlib~=3.9.0


### PR DESCRIPTION
## Summary
- include matplotlib for chart generation
- embed sales and inventory charts in PDF

## Testing
- `python -m py_compile app/routers/informe.py`

------
https://chatgpt.com/codex/tasks/task_e_6875611b83b083328def2466fa4e5974