### PR TITLE
Enable cascade deletes for inventory tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,18 @@ Version 2 adds indexes to various timestamp columns (`facturas.fecha`, `cierres_
 `entradas_insumo.fecha`, `salidas_insumo.fecha` y `movimientos.fecha`).
 Si ya tienes las tablas creadas ejecuta manualmente `CREATE INDEX` para cada
 columna o recrea las tablas para aprovechar los nuevos índices.
+
+## Foreign key cascades
+
+Versión 3 cambia las relaciones de `entradas_insumo` y `salidas_insumo` para
+eliminar automáticamente los registros asociados cuando un `insumo` se borra.
+Debes recrear las tablas para que los `FOREIGN KEY` tengan `ON DELETE CASCADE`.
+
+Ejecuta:
+
+```bash
+python scripts/recreate_tables.py
+```
+
+Esto eliminará todas las tablas y las volverá a crear con las claves
+actualizadas.

--- a/app/models.py
+++ b/app/models.py
@@ -66,7 +66,7 @@ class CierreCaja(Base):
 class EntradaInsumo(Base):
     __tablename__ = "entradas_insumo"
     id = Column(Integer, primary_key=True)
-    insumo_id = Column(Integer, ForeignKey("insumos.id"))
+    insumo_id = Column(Integer, ForeignKey("insumos.id", ondelete="CASCADE"))
     cantidad = Column(Float, nullable=False)
     fecha = Column(DateTime, default=datetime.now, index=True)
 
@@ -75,7 +75,7 @@ class EntradaInsumo(Base):
 class SalidaInsumo(Base):
     __tablename__ = "salidas_insumo"
     id = Column(Integer, primary_key=True)
-    insumo_id = Column(Integer, ForeignKey("insumos.id"))
+    insumo_id = Column(Integer, ForeignKey("insumos.id", ondelete="CASCADE"))
     cantidad = Column(Float, nullable=False)
     fecha = Column(DateTime, default=datetime.now, index=True)
 
@@ -93,8 +93,18 @@ class Insumo(Base):
     unidad = Column(String, nullable=False)
     minimo = Column(Float, nullable=False)
 
-    entradas = relationship("EntradaInsumo", back_populates="insumo", cascade="all, delete")
-    salidas = relationship("SalidaInsumo", back_populates="insumo", cascade="all, delete")
+    entradas = relationship(
+        "EntradaInsumo",
+        back_populates="insumo",
+        cascade="all, delete",
+        passive_deletes=True,
+    )
+    salidas = relationship(
+        "SalidaInsumo",
+        back_populates="insumo",
+        cascade="all, delete",
+        passive_deletes=True,
+    )
     movimientos = relationship("MovimientoInsumo", back_populates="insumo", cascade="all, delete")
 
 

--- a/scripts/recreate_tables.py
+++ b/scripts/recreate_tables.py
@@ -1,0 +1,9 @@
+from app.database import Base, engine
+from app import models
+
+if __name__ == "__main__":
+    print("Dropping tables...")
+    Base.metadata.drop_all(engine)
+    print("Creating tables...")
+    Base.metadata.create_all(engine)
+    print("Done.")


### PR DESCRIPTION
## Summary
- allow cascading deletes from `Insumo` to `EntradaInsumo` and `SalidaInsumo`
- expose passive delete handling in relationships
- add script to easily recreate tables
- document new migration requirement

## Testing
- `python -m py_compile app/models.py scripts/recreate_tables.py`

------
https://chatgpt.com/codex/tasks/task_e_6878189b7fdc8332a1383706534967f1